### PR TITLE
Corrige semántica del texto en negrilla y mejora usabilidad de los links

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -40,6 +40,7 @@ a {
   all: unset;
   color: inherit;
   text-decoration: none;
+  cursor: pointer;
 }
 
 .beta-text {

--- a/index.html
+++ b/index.html
@@ -23,7 +23,11 @@
   </head>
   <body>
     <main class="main-content mb-5">
-      <img class="img-main" src="./assets/images/avatar.jpeg" alt="My Scrimba avatar." />
+      <img
+        class="img-main"
+        src="./assets/images/avatar.jpeg"
+        alt="My Scrimba avatar."
+      />
       <h2>Javier Figueroa</h2>
       <span class="subheading">Desarrollador Frontend</span>
 
@@ -33,12 +37,12 @@
       </p>
       <div class="d-flex gap-5 m-0 btn-container">
         <button
-            class="btn btn-primary w-100 m-0"
-            onclick="window.location.href='./proyectos.html'"
-          >
-            Portafolio
-          </button>
-          <button
+          class="btn btn-primary w-100 m-0"
+          onclick="window.location.href='./proyectos.html'"
+        >
+          Portafolio
+        </button>
+        <button
           class="btn btn-primary w-100 m-0"
           onclick="window.location.href='./proyectos.html'"
         >
@@ -79,7 +83,7 @@
             de Aplicaciones Multiplataforma.
           </li>
           <li>
-            <strong>META - COURSEA</strong> online 2023 Desarrollo Frontend
+            <strong>META - COURSERA</strong> online 2023 Desarrollo Frontend
           </li>
           <li>
             <strong>Academia Desafio Latam</strong> online 2023 Desarrollo
@@ -89,19 +93,18 @@
         <h1>Experiencia</h1>
         <ul class="info">
           <li>
-            <strong>Mayo 2023 a la fecha.</strong> Desarrollador • Frontend •
-            Incubadora Desafio Latam Proyecto InnovaxD Desarrollo de una
-            aplicación web en colaboración con Microsoft y El Mercurio para
-            noticias enfocada en niños
+            <b>Mayo 2023 a la fecha.</b> Desarrollador • Frontend • Incubadora
+            Desafio Latam Proyecto InnovaxD Desarrollo de una aplicación web en
+            colaboración con Microsoft y El Mercurio para noticias enfocada en
+            niños
           </li>
           <li>
-            <strong>Mayo 2018 – Diciembre 2022</strong>. Propietario •
-            Transpores Gaman Empresa de logística y transporte dedicada a última
-            Milla.
+            <b>Mayo 2018 – Diciembre 2022</b>. Propietario • Transpores Gaman
+            Empresa de logística y transporte dedicada a última Milla.
           </li>
           <li>
-            <strong>Enero 2020 - Octubre 2021</strong>. Propietario • Comercial
-            RyF Elaboración de productos para el área gastronómica
+            <b>Enero 2020 - Octubre 2021</b>. Propietario • Comercial RyF
+            Elaboración de productos para el área gastronómica
           </li>
         </ul>
       </div>


### PR DESCRIPTION
Las etiquetas strong se usan para resaltar fragmentos de texto por ser más relevantes dentro de su contexto (creo que no es el caso de las fechas en la sección de experiencia), por eso las cambié por etiquetas b, que no tienen ningún significado semántico, pero cumplen con poner el texto en negrilla.

Cambié el tipo de cursor para las etiquetas anchor, pues eso permite que los usuarios se den cuenta que el hacer click en ese punto tiene algún efecto.